### PR TITLE
Replace apt with apt-get to prevent big red warning text

### DIFF
--- a/DOCKERFILE.jammy
+++ b/DOCKERFILE.jammy
@@ -15,10 +15,10 @@ MAINTAINER Jason Barnett <xasmodeanx@gmail.com>
 ARG DEBIAN_FRONTEND=noninteractive
 
 #Start with an up-to-date basis
-RUN apt update; apt upgrade -y
+RUN apt-get update; apt-get upgrade -y
 
 #Install some useful tools
-RUN apt install -y bash supervisor curl net-tools nano apt-transport-https wget bc gpg
+RUN apt-get install -y bash supervisor curl net-tools nano apt-transport-https wget bc gpg
 
 #Copy in our files...
 COPY overlay /
@@ -32,10 +32,10 @@ RUN echo "deb [signed-by=/usr/share/keyrings/elastic.gpg] https://artifacts.elas
 #Elastic 8.x repo setup
 #RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
 #RUN echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-8.x.list
-RUN apt update
-RUN apt install -y elasticsearch kibana
+RUN apt-get update
+RUN apt-get install -y elasticsearch kibana
 #Optional: install filebeat and logstash
-#RUN apt install -y filebeat logstash
+#RUN apt-get install -y filebeat logstash
 #Use pre-configured settings for elasticsearch and kibana
 RUN rm -fv /etc/elasticsearch/elasticsearch.yml; mkdir -p /usr/share/elasticsearch/config/; cp -fv /elasticsearch/elasticsearch.yml /usr/share/elasticsearch/config/; ln -sfv /usr/share/elasticsearch/config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml; mkdir -p /usr/share/elasticsearch/data; chown -R elasticsearch:elasticsearch /usr/share/elasticsearch
 RUN rm -fv /etc/kibana/kibana.yml; mkdir -p /usr/share/kibana/config/; cp /kibana/kibana.yml /usr/share/kibana/config/; ln -sfv /usr/share/kibana/config/kibana.yml /etc/kibana/kibana.yml
@@ -45,7 +45,7 @@ RUN rm -fv /etc/kibana/kibana.yml; mkdir -p /usr/share/kibana/config/; cp /kiban
 #Clean up			                              		#
 #################################################
 RUN rm -rf /var/lib/apt/lists/*
-RUN apt clean
+RUN apt-get clean
 
 
 #################################################


### PR DESCRIPTION
Big Red Warning Text:
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Suggest we switch to apt-get