### PR TITLE
Simplify docker image handling and add optional compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.exe
 *.dbg
 *.docker
-*.tar.gz
-
+*.tar
+*.gz
+*.bz2
+*.xz


### PR DESCRIPTION
We don't need to tar a tarball since docker outputs tar formatted images and understand compression nativly.

See examples:
COMPRESSION=gz ./build_siglasticsearch_image_and_container.sh rebuild
COMPRESSION=bz2 ./build_siglasticsearch_image_and_container.sh rebuild
COMPRESSION=xz ./build_siglasticsearch_image_and_container.sh rebuild